### PR TITLE
Fix CI: scipy top-level imports and auto-merge error

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -79,7 +79,7 @@ jobs:
             --body "Automated weekly data refresh. Merging this will trigger the chart-update workflow." \
             --base main \
             --head "$BRANCH"
-          gh pr merge "$BRANCH" --auto --squash
+          gh pr merge "$BRANCH" --squash
 
       - name: Open issue on failure
         if: failure()

--- a/analysis/ECOS_budgets_viz.py
+++ b/analysis/ECOS_budgets_viz.py
@@ -3,8 +3,6 @@ import pandas as pd
 import numpy as np
 from sqlalchemy import create_engine
 import chartjs
-from scipy.stats import pearsonr
-
 import matplotlib as mpl
 color_cycle = [c['color'] for c in list(mpl.rcParams['axes.prop_cycle'])]
 

--- a/analysis/MADEP_enforcements_viz.py
+++ b/analysis/MADEP_enforcements_viz.py
@@ -201,6 +201,7 @@ def generate_charts(engine, prefix=''):
 	mychart.jekyll_write(f'../docs/_includes/charts/{prefix}MADEP_enforcement_vsbudget.html')
 
 	## Output correlation level
+	from scipy.stats import pearsonr
 	pr = pearsonr(s_data_g.values, (f_data['DEPAdministration_inf_float'].loc[years]/1e6).values)
 	with open(fact_file, 'a') as f:
 		f.write('cor_enforcement_funding: %0.0f'%(pr[0]*100)+'\n')


### PR DESCRIPTION
## Summary
- Move `scipy.stats.pearsonr` to local imports at call sites in `MADEP_enforcements_viz.py` and `MADEP_staff.py`; remove unused import from `ECOS_budgets_viz.py` — scipy is not in `requirements-ci.txt`, so top-level imports broke `dashboard_charts.py` on every chart update run
- Remove `--auto` from `gh pr merge` in `update-data.yml` — auto-merge requires branch protection with required checks; without it GitHub returns a GraphQL error and fails the workflow despite the PR being created successfully

## Test plan
- [ ] Trigger `update-charts` workflow manually and confirm no `ModuleNotFoundError: No module named 'scipy'`
- [ ] Trigger `update-data` workflow manually and confirm no `GraphQL: Pull request is in clean status` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)