### PR TITLE
Fix CI: add missing dependencies, optional stan import, and DB download step

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements-ci.txt
 
+      - name: Download AMEND database from GCS
+        run: curl -fsSL https://storage.googleapis.com/openamend-data/amend.db -o get_data/AMEND.db
+
       - name: Generate dashboard charts
         working-directory: analysis
         run: python dashboard_charts.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@ All Python scripts run in the `amend_python` conda environment:
 conda activate amend_python
 ```
 
-Scripts that are part of the CI pipeline use `requirements-ci.txt` (no PySTAN, geopandas, or joblib; scipy is imported inline only where needed and is not listed).  The full conda env is needed to run the analysis/visualization scripts locally.
+Scripts that are part of the CI pipeline use `requirements-ci.txt`. The only excluded dep is PySTAN (`stan`). Everything else needed by `dashboard_charts.py` and its transitive imports must be listed there. The full conda env is needed to run the analysis/visualization scripts locally.
+
+**When adding a new import to any script in the `dashboard_charts.py` call chain**, check whether the package is in `requirements-ci.txt` and add it with a pinned version if not. The full import chain is: `dashboard_charts.py` → `MADEP_staff`, `MADEP_enforcements_viz`, `ECOS_budgets_viz`, `EPA_303d_viz`, `EEA_DP_CSO_map` → `NECIR_CSO_map` → `cso_maps`. To find the pinned version: `conda run -n amend_python python -c "import pkg_resources; print(pkg_resources.get_distribution('PKGNAME').version)"`.
 
 ## Repository layout
 

--- a/analysis/NECIR_CSO_map.py
+++ b/analysis/NECIR_CSO_map.py
@@ -34,7 +34,13 @@ import numpy as np
 from shapely.geometry import Point, shape
 from shapely.strtree import STRtree
 import sqlalchemy
-import stan
+# stan (pystan3) is only used in fit_stan_model(), which is only called when
+# make_regression=True. CI runs with make_regression=False and does not install
+# stan, so we make the import optional to avoid a ModuleNotFoundError at import time.
+try:
+    import stan
+except ImportError:
+    stan = None
 
 # Create a joblib cache
 memory = Memory('necir_cso_data_cache', verbose=1)
@@ -659,8 +665,8 @@ class CSOAnalysis():
     # Regression modeling methods
     # -------------------------
     
-    def fit_stan_model(self, col: str, data_egs_merge: pd.DataFrame, level_df: pd.DataFrame, 
-        df_cso_level: pd.DataFrame, level_col: str='Watershed') -> Tuple[stan.fit.Fit, pd.DataFrame, dict, np.ndarray]:
+    def fit_stan_model(self, col: str, data_egs_merge: pd.DataFrame, level_df: pd.DataFrame,
+        df_cso_level: pd.DataFrame, level_col: str='Watershed') -> Tuple[Any, pd.DataFrame, dict, np.ndarray]:
         """Fit Stan model for a particular EJ characteristic (`col`)
         """
         logging.info(f'Building stan model for {col}')

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -20,6 +20,7 @@ us==3.2.0
 # Visualization (charts + maps; no pystan/geopandas)
 matplotlib==3.10.8
 folium==0.20.0
+plotly==6.6.0
 
 # Misc
 six==1.17.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,6 @@
 # Dependencies for CI data fetching and chart generation.
-# Excludes heavy deps only needed for local PySTAN analysis (pystan, geopandas, scipy, joblib).
+# Excludes PySTAN (stan) only -- geopandas/shapely/joblib/scipy are needed by the chart pipeline
+# via the NECIR_CSO_map → EEA_DP_CSO_map → dashboard_charts import chain.
 
 # HTTP / scraping
 requests==2.33.1
@@ -17,10 +18,20 @@ sqlalchemy==2.0.48
 sodapy==2.2.0
 us==3.2.0
 
-# Visualization (charts + maps; no pystan/geopandas)
+# Visualization (charts + maps)
 matplotlib==3.10.8
 folium==0.20.0
 plotly==6.6.0
+
+# Geospatial (required by NECIR_CSO_map → EEA_DP_CSO_map import chain)
+geopandas==1.1.3
+shapely==2.1.2
+pyproj==3.6.0
+fiona==1.9.4.post1
+
+# Numerical / stats (scipy used inline in MADEP scripts; joblib used by NECIR_CSO_map)
+scipy==1.17.1
+joblib==1.2.0
 
 # Misc
 six==1.17.0


### PR DESCRIPTION
## Summary

Fixes a chain of failures in the `update-charts` workflow:

1. **Missing packages in `requirements-ci.txt`** — `plotly`, `geopandas`, `shapely`, `pyproj`, `fiona`, `scipy`, `joblib` are all required by the `dashboard_charts.py` transitive import chain (`EEA_DP_CSO_map` → `NECIR_CSO_map` → `cso_maps`) but were not listed

2. **Top-level `import stan` in `NECIR_CSO_map.py`** — Stan is only used inside `fit_stan_model()` which is only called when `make_regression=True` (disabled in CI). Wrapped in `try/except ImportError` with explanatory comment.

3. **No database in CI** — The `update-charts` workflow ran against a fresh checkout with no `AMEND.db`. Added a step to download it from GCS (`gs://openamend-data/amend.db`) which is public-read and requires no auth.

Also updates `CLAUDE.md` to document the import chain and how to check package versions when adding new imports.

Verified working: https://github.com/nesanders/MAenvironmentaldata/actions/runs/24628282008

Fixes CI failures:
- https://github.com/nesanders/MAenvironmentaldata/actions/runs/24628039671 (`plotly`)
- https://github.com/nesanders/MAenvironmentaldata/actions/runs/24628089007 (`geopandas`)
- https://github.com/nesanders/MAenvironmentaldata/actions/runs/24628161392 (`stan`)
- https://github.com/nesanders/MAenvironmentaldata/actions/runs/24628219565 (`MADEP_staff` table missing)

## Test plan

- [x] `update-charts` workflow succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)