### PR TITLE
Fix chart workflow not triggering after bot-merged data PRs

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -1,14 +1,15 @@
 name: Update Charts
 
 on:
-  # Trigger when data files land on main (after the data-update PR auto-merges).
-  # This replaces the old workflow_run trigger so sequencing is correct:
-  # data PR merges → push event fires → charts regenerate with fresh data.
+  # Primary trigger: explicitly dispatched by update-data.yml after its PR merges.
+  # (GitHub does not fire push events from GITHUB_TOKEN bot merges, so on:push
+  # alone is not reliable for bot-initiated data updates.)
+  # Fallback: push to main touching docs/data/** covers human-initiated merges.
   push:
     branches: [main]
     paths:
       - 'docs/data/**'
-  workflow_dispatch:       # Allow manual trigger from GitHub UI
+  workflow_dispatch:       # Primary trigger from update-data.yml; also allows manual runs
 
 concurrency:
   group: update-charts

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -84,6 +84,7 @@ jobs:
             --base main \
             --head "$BRANCH"
           gh pr merge "$BRANCH" --squash
+          gh workflow run update-charts.yml --ref main
 
       - name: Open issue on failure
         if: failure()


### PR DESCRIPTION
## Summary
- GitHub does not fire `on: push` events for commits made by `GITHUB_TOKEN` (loop-prevention), so the chart workflow was silently skipped after every weekly data bot merge
- Fix: add `gh workflow run update-charts.yml --ref main` after `gh pr merge` in update-data.yml — explicit dispatch is not subject to the loop-prevention restriction
- Update comment in update-charts.yml to document the primary vs. fallback trigger

## Test plan
- [ ] Manually trigger `update-charts.yml` via workflow_dispatch on this PR branch to verify charts generate successfully
- [ ] After merging, confirm next data update run dispatches the chart workflow automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)