### PR TITLE
ci: replace cross-workflow dispatch with three self-contained workflows

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -1,15 +1,7 @@
-name: Update Charts
+name: Update Charts Only
 
 on:
-  # Primary trigger: explicitly dispatched by update-data.yml after its PR merges.
-  # (GitHub does not fire push events from GITHUB_TOKEN bot merges, so on:push
-  # alone is not reliable for bot-initiated data updates.)
-  # Fallback: push to main touching docs/data/** covers human-initiated merges.
-  push:
-    branches: [main]
-    paths:
-      - 'docs/data/**'
-  workflow_dispatch:       # Primary trigger from update-data.yml; also allows manual runs
+  workflow_dispatch:       # Manual trigger only
 
 concurrency:
   group: update-charts
@@ -71,10 +63,10 @@ jobs:
           git push origin "$BRANCH"
           gh pr create \
             --title "Auto-update dashboard charts $(date -u +%Y-%m-%d)" \
-            --body "Automated chart regeneration triggered by data update." \
+            --body "Manual chart regeneration against current GCS database." \
             --base main \
             --head "$BRANCH"
-          gh pr merge "$BRANCH" --auto --squash
+          gh pr merge "$BRANCH" --squash
 
       - name: Open issue on failure
         if: failure()

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -1,13 +1,19 @@
-name: Update Data Only
+name: Weekly Update (Data + Charts)
 
 on:
-  workflow_dispatch:       # Manual trigger only
+  schedule:
+    - cron: '0 6 * * 1'  # Every Monday at 6am UTC
+  workflow_dispatch:       # Allow manual trigger from GitHub UI
+
+concurrency:
+  group: update-weekly
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  update-data:
+  update:
     runs-on: ubuntu-latest
     permissions:
       contents: write       # to push branch
@@ -61,24 +67,39 @@ jobs:
         working-directory: get_data
         run: python assemble_db.py
 
+      - name: Generate dashboard charts
+        working-directory: analysis
+        run: python dashboard_charts.py
+
+      - name: Write timestamps
+        run: |
+          echo "updated: $(date -u +'%Y-%m-%d %H:%M:%S')" > docs/data/ts_update_dashboard.yml
+
       - name: Commit and open PR
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/data/
+          git add docs/data/ \
+                  docs/_includes/charts/dash_*.html \
+                  docs/data/facts_dash_*.yml \
+                  docs/data/facts_DEPstaff.yml \
+                  docs/data/facts_DEPenforce.yml \
+                  docs/data/facts_ECOSbudgets.yml \
+                  docs/data/facts_EPA303d.yml \
+                  docs/data/ts_update_dashboard.yml
           if git diff --staged --quiet; then
-            echo "No data changes — skipping PR."
+            echo "No changes — skipping PR."
             exit 0
           fi
-          BRANCH="auto/data-$(date -u +%Y-%m-%d)"
+          BRANCH="auto/weekly-$(date -u +%Y-%m-%d)"
           git checkout -b "$BRANCH"
-          git commit -m "Auto-update data $(date -u +%Y-%m-%d)"
+          git commit -m "Auto-update data + charts $(date -u +%Y-%m-%d)"
           git push origin "$BRANCH"
           gh pr create \
-            --title "Auto-update data $(date -u +%Y-%m-%d)" \
-            --body "Manual data-only refresh. Run 'Update Charts Only' separately to regenerate dashboard charts." \
+            --title "Auto-update data + charts $(date -u +%Y-%m-%d)" \
+            --body "Automated weekly data and chart refresh." \
             --base main \
             --head "$BRANCH"
           gh pr merge "$BRANCH" --squash
@@ -91,9 +112,9 @@ jobs:
             github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Data update failed: ${new Date().toISOString().split('T')[0]}`,
+              title: `Weekly update failed: ${new Date().toISOString().split('T')[0]}`,
               body: [
-                '## Manual data update failed',
+                '## Scheduled weekly update failed',
                 '',
                 `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
                 '',


### PR DESCRIPTION
## Problem

`GITHUB_TOKEN` cannot trigger `workflow_dispatch` events on other workflows — a hard GitHub security restriction regardless of `actions: write` permission. This caused the weekly data run to fail with HTTP 403 when trying to dispatch `update-charts.yml`.

## Solution

Three fully self-contained workflows — no cross-dispatch:

| Workflow | Trigger | What it does |
|---|---|---|
| **Weekly Update** (`update-weekly.yml`) | Scheduled Mon 06:00 UTC + manual | Full data fetch → validate → assemble DB → generate charts → one PR |
| **Update Data Only** (`update-data.yml`) | Manual only | Data fetch → validate → assemble DB → PR with `docs/data/` |
| **Update Charts Only** (`update-charts.yml`) | Manual only | Downloads DB from GCS → generate charts → PR with `docs/_includes/charts/` |

Note: lobbying pipeline scripts (`get_MA_lobbying.py` etc.) are omitted from the weekly workflow here — they will be added when `feat/ma-lobbying-data` is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)