### PR TITLE
Harden precipitation fetch against partial ACIS responses

### DIFF
--- a/analysis/EEA_DP_CSO_map.py
+++ b/analysis/EEA_DP_CSO_map.py
@@ -189,7 +189,7 @@ class CSOAnalysisEEADP(CSOAnalysis):
             precip_monthly = df_rain[
                 (df_rain['date'] >= pd.to_datetime(self.cso_data_start)) &
                 (df_rain['date'] <= pd.to_datetime(self.cso_data_end))
-            ].resample('MS', on='date')['precip_in_avg'].sum()
+            ].resample('MS', on='date')['precip_in_avg'].sum(min_count=1)
             precip_monthly = precip_monthly.reindex(all_months, fill_value=0)
             mychart.add_dataset(
                 precip_monthly.values.tolist(),
@@ -961,7 +961,7 @@ class CSOAnalysisEEADP(CSOAnalysis):
             precip_monthly = df_rain[
                 (df_rain['date'] >= pd.to_datetime(self.cso_data_start)) &
                 (df_rain['date'] <= pd.to_datetime(self.cso_data_end))
-            ].resample('MS', on='date')['precip_in_avg'].sum()
+            ].resample('MS', on='date')['precip_in_avg'].sum(min_count=1)
         else:
             precip_monthly = pd.Series(0, index=pd.date_range(start=pd.to_datetime(self.cso_data_start), end=pd.to_datetime(self.cso_data_end), freq='MS'))
 

--- a/get_data/get_MA_precipitation.py
+++ b/get_data/get_MA_precipitation.py
@@ -33,7 +33,10 @@ def fetch_daily_precip_year(year: int) -> pd.DataFrame:
     n_stations (number of stations reporting that day).
     """
     sdate = f'{year}-01-01'
-    edate = f'{year}-12-31'
+    edate = min(
+        datetime.date(year, 12, 31),
+        datetime.date.today(),
+    ).strftime('%Y-%m-%d')
     resp = requests.post(ACIS_URL, json={
         'state': 'MA',
         'sdate': sdate,
@@ -50,8 +53,6 @@ def fetch_daily_precip_year(year: int) -> pd.DataFrame:
     for stn in stations:
         name = stn['meta']['name']
         rows = stn['data']
-        if len(rows) != len(dates):
-            continue
         vals = []
         for v in rows:
             raw = v[0]
@@ -62,7 +63,12 @@ def fetch_daily_precip_year(year: int) -> pd.DataFrame:
                     vals.append(float(raw))
                 except ValueError:
                     vals.append(np.nan)
-        columns[name] = vals
+        # Align to the full date range regardless of how many rows ACIS returned.
+        # A station with a partial response (e.g. 364 of 365 days) contributes its
+        # valid days rather than being dropped entirely.
+        stn_index = pd.date_range(sdate, periods=len(vals), freq='D')
+        stn_series = pd.Series(vals, index=stn_index).reindex(dates)
+        columns[name] = stn_series.values
 
     matrix = pd.DataFrame(columns, index=dates, dtype=float)
 


### PR DESCRIPTION
## Summary

Two defensive fixes to the precipitation pipeline, found while investigating the dry-weather CSO cohort. Neither changes current outputs — see verification below — but both remove latent failure modes that would silently corrupt the rainfall data feeding the dashboard and any dry-weather analysis.

## Changes

**`get_data/get_MA_precipitation.py`** — The station loop silently dropped any station whose row count didn't match the full-calendar-year date range. ACIS currently pads every station's response to the requested range (filling future/missing days with `'M'`), so the guard never fires today — but if ACIS ever returns a short array (partial response, mid-year truncation), the old code would discard those stations wholesale with no warning, silently degrading the statewide average. Now:
- `edate` is capped at today, so the current year doesn't request (or write) future-dated rows. The cached CSV currently carries 228 all-NaN rows for the rest of 2026; those go away on the next fetch.
- Each station is reindexed to the requested range, so a partial response contributes its valid days instead of being dropped entirely.

**`analysis/EEA_DP_CSO_map.py`** — Monthly precipitation aggregation used `.sum()`, which returns **0** (not NaN) for a month with no data, rendering a data gap as "zero rainfall" on the dashboard's monthly volume + rainfall chart. `min_count=1` makes such months honest gaps. No currently shipped month is affected (verified all months in the live chart have real values); this guards the display if the precip fetch ever falls behind the CSO data window.

## Verification (no regression)

Fetched live ACIS data (2026-06-10) and processed the same responses under old and new logic, for 2022–2026:

- Daily statewide averages: identical where both are defined (max |diff| = 0.000").
- Station coverage: identical per year (the length guard never fires against current ACIS responses).
- Statewide-dry CSO cohort (`precip_48h < 0.05"` across all 17,732 incidents): **unchanged** at 1,955 events / 1,987 Mgal; zero events flip classification.
- Cached CSV values match a fresh fetch to within 0.008" on overlapping 2026 days.

## Out of scope / follow-up

The larger dry-weather question is methodological, not pipeline: the statewide average smooths localized storms to near-zero, so most "dry" events have substantial operator-reported rainfall at the outfall (`MAEEADP_CSO.rainfallData`). Redefining the dry cohort using local precipitation is being pursued separately.

Also out of scope: the fetch script only re-fetches from the most recent cached year, so any historical correction would require forcing a full re-fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)