### PR TITLE
Align rain–discharge windows with ACIS observation-day dating

### DIFF
--- a/analysis/EEA_DP_CSO_map.py
+++ b/analysis/EEA_DP_CSO_map.py
@@ -193,7 +193,7 @@ class CSOAnalysisEEADP(CSOAnalysis):
             precip_monthly = precip_monthly.reindex(all_months, fill_value=0)
             mychart.add_dataset(
                 precip_monthly.values.tolist(),
-                'Precipitation (48-hr lookback)',
+                'Precipitation (monthly total)',
                 borderColor="'rgba(100,150,255,1)'",
                 type="'line'",
                 fill="false",
@@ -582,11 +582,17 @@ class CSOAnalysisEEADP(CSOAnalysis):
             return None, None
         df_rain['date'] = pd.to_datetime(df_rain['date'])
         df_rain = df_rain.sort_values('date').set_index('date')
+        # ACIS daily precipitation is observation-day dated: most COOP stations
+        # observe in the morning and attribute the preceding ~24 hours of rain to
+        # the observation day, so rain that falls on day d is predominantly
+        # recorded on day d+1.  Shift the series back one day to approximate
+        # physical-day alignment, then window over the event day and the
+        # day(s) before it.
+        precip_physical = df_rain['precip_in_avg'].shift(-1)
         prior_rain = (
-            df_rain['precip_in_avg']
+            precip_physical
             .rolling(window=window_days, min_periods=1)
             .sum()
-            .shift(1)
             .rename('prior_rain_in')
         )
 
@@ -989,7 +995,7 @@ class CSOAnalysisEEADP(CSOAnalysis):
         # Add rainfall as line on secondary axis
         mychart.add_dataset(
             precip_monthly.values.tolist(),
-            "Precipitation (48-hr lookback)",
+            "Precipitation (monthly total)",
             borderColor="'rgba(100,150,255,1)'",
             type="'line'",
             fill="false",

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -161,9 +161,12 @@ Regulated sewer operators report CSO and SSO discharge events to the EEA Data Po
 waterbody, and operator identity. Rainfall data comes from NOAA ACIS, averaging daily
 precipitation across Massachusetts GHCN and NWS COOP weather stations.
 
-Discharge counts and volumes are tabulated by month and year. The rainfall chart uses a
-48-hour lookback window for precipitation totals, following
-<a href="https://iwaponline.com/wst/article/86/11/2848/91816/">Bizer & Kirchhoff (2022)</a>.
+Discharge counts and volumes are tabulated by month and year, with monthly precipitation
+totals overlaid. Rainfall–discharge comparisons in the full analysis use a 48-hour lookback
+window, following
+<a href="https://iwaponline.com/wst/article/86/11/2848/91816/">Bizer & Kirchhoff (2022)</a>,
+shifted one day to account for station observation-day reporting (most stations attribute
+rain to the morning observation following the day it falls).
 Operator volumes are shown as annual trends for the top 10 operators, illustrating how each operator's 
 discharge volumes change year-to-year. Note that 2022 data covers only the second half of the calendar year; 
 the first full calendar year of data is 2023.


### PR DESCRIPTION
## Problem

Most COOP/GHCN stations observe in the morning and attribute the preceding 24 hours of rain to the observation day, so rain that falls on day *x* is predominantly recorded in `MA_precipitation_daily` on day *x+1*. The shared prior-rain helper in `EEA_DP_CSO_map.py` compounds this: `rolling(2).sum().shift(1)` produces a `[d−2, d−1]` recorded-day window, which excludes the event day and misses the next-day-dated storm rain entirely.

The result is that storm-triggered discharges systematically appear to have happened in dry weather. Three independent lines of evidence:

- Of the 1,041 events classified "dry" (statewide 48-hr rain < 0.05", Verified Data Reports), **90% have ≥ 0.05" of statewide rain recorded the day after the event** (median 0.30").
- Operator-reported rainfall (`rainfallData`) correlates best with statewide precip at **day +1** (r = 0.21) vs day 0 (0.14) and day −1 (0.00) — the fingerprint of observation-day dating.
- Correcting the window restores the physically expected rain–discharge relationship (numbers below).

## Fix

In `_load_rain_and_cso`: shift the daily precip series back one day (recorded → physical alignment) and drop the trailing `.shift(1)`, so the window covers the event day and the day before it in physical time.

Also:
- Relabels the monthly chart rainfall overlay from "Precipitation (48-hr lookback)" to "Precipitation (monthly total)" — it has always plotted monthly sums.
- Documents the observation-day convention in the dashboard methodology note.

## Effect (verified against AMEND.db, 2022-06-30 → 2026-04-19)

| Metric | Before | After |
|---|---|---|
| corr(prior 48-hr rain, daily discharge volume) | 0.01 | **0.58** |
| Spearman | 0.08 | **0.61** |
| Fraction of dry days (<0.05") with any discharge | 34% | **11%** |
| "Dry-weather" events (statewide 48-hr < 0.05") | 1,041 | **63** |

## Implications for the 2026-04 post

The post's "surprisingly weak rainfall↔discharge relationship" and the dry-weather discharge framing (34% of dry days → NPDES violations) are largely artifacts of this window. The post's charts use frozen `MAEEADP_through_2025_*` filenames and are **not regenerated here** — flagging for your call on whether to refresh them and/or revise the post text. The corrected dry cohort (63 events; ~half still showing operator-reported rain, so a defensible infrastructure-failure set is ~30–60 events) still concentrates in Fall River, New Bedford, and Springfield.

## Notes

- The dashboard monthly chart label fix deploys automatically on the next weekly chart CI run; the prior-rain charts (`rainfall_discharge_freq`/`scatter`/`cdf`) are not currently generated by `dashboard_charts.py`.
- The one-day shift is an approximation: observation times vary by station (ASOS stations are midnight-dated). Per-station observation-time handling via ACIS metadata, or gridded NOAA AORC, would be more rigorous follow-ups.
- Independent of #82 (no overlapping lines; merges cleanly in either order).
- Minor related issue, not fixed here: the ACIS parser maps `'T'` (trace, ~4.6% of station-days) to NaN instead of 0.0, slightly biasing the statewide mean wet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
