### PR TITLE
fix(ai): avoid window-function SQL + guarded auto-repair loop (max 3)

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,0 +1,25 @@
+name: JS unit tests
+
+# Runs the dependency-free node:test suite for the client-side AI-analysis
+# helpers. Triggered only when the relevant JS changes.
+on:
+  pull_request:
+    paths:
+      - 'docs/assets/*.js'
+      - '.github/workflows/js-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/assets/*.js'
+      - '.github/workflows/js-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run JS unit tests
+        run: node --test docs/assets/

--- a/docs/ai_analysis.html
+++ b/docs/ai_analysis.html
@@ -93,10 +93,11 @@ Supported providers: <a href="https://console.groq.com" target="_blank">Groq</a>
           <option value="o3">o3 (reasoning, slow)</option>
         </select>
         <select id="ai-model-select-gemini" style="display:none">
-          <option value="gemini-2.5-flash">gemini-2.5-flash (default)</option>
-          <option value="gemini-2.5-pro">gemini-2.5-pro (most capable)</option>
-          <option value="gemini-2.0-flash">gemini-2.0-flash</option>
-          <option value="gemini-2.0-flash-lite">gemini-2.0-flash-lite (fastest)</option>
+          <option value="gemini-flash-latest">gemini-flash-latest (default)</option>
+          <option value="gemini-pro-latest">gemini-pro-latest (most capable)</option>
+          <option value="gemini-flash-lite-latest">gemini-flash-lite-latest (fastest)</option>
+          <option value="gemini-2.5-flash">gemini-2.5-flash</option>
+          <option value="gemini-2.5-pro">gemini-2.5-pro</option>
         </select>
       </label>
       <label>Custom model override:

--- a/docs/assets/ai_analysis.css
+++ b/docs/assets/ai_analysis.css
@@ -492,6 +492,37 @@
   font-family: 'Courier New', monospace;
 }
 
+/* ─── SQL diagnostics + build tag ────────────────────────────────────────── */
+
+.ai-diagnostic {
+  background: #f4f7fb;
+  border-left: 3px solid #90a4c8;
+}
+.ai-diagnostic--error {
+  background: #fdecea;
+  border-left-color: #c62828;
+}
+.ai-diagnostic--success {
+  background: #eaf6ea;
+  border-left-color: #2e7d32;
+}
+.ai-diag-title {
+  font-size: 0.8em;
+  font-weight: 600;
+  color: #555;
+}
+.ai-diagnostic--error .ai-diag-title { color: #c62828; }
+.ai-diagnostic--success .ai-diag-title { color: #2e7d32; }
+
+.ai-diag-earlier > summary {
+  cursor: pointer;
+  color: #666;
+}
+.ai-diag-earlier-label {
+  margin-top: 8px;
+  color: #c62828;
+}
+
 /* ─── Data Table ─────────────────────────────────────────────────────────── */
 .ai-data-section {
   margin-top: 8px;

--- a/docs/assets/ai_analysis.js
+++ b/docs/assets/ai_analysis.js
@@ -23,6 +23,16 @@ const DB_URL = 'https://storage.googleapis.com/openamend-data/amend.db.gz';
 const SCHEMA_QUERY = "SELECT name, sql FROM sqlite_master WHERE type='table' ORDER BY name";
 const MAX_PREVIEW_ROWS = 20;
 const WRITE_BLOCK_RE = /\b(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE)\b/i;
+// Max automatic SQL repair attempts: on a SQLite error we feed the failing SQL +
+// error back to the model to correct, up to this many times, before giving up.
+const MAX_SQL_RETRIES = 3;
+
+// Normalize model-generated SQL before execution. Currently quotes the reserved
+// word "index" (a pandas artifact column) when it appears outside string
+// literals. Applied to both first-pass and retried SQL.
+function normalizeGeneratedSql(sql) {
+  return sql.replace(/\b(index)\b(?=(?:[^"]*"[^"]*")*[^"]*$)/gi, '"index"');
+}
 
 const PROVIDER_CONFIG = {
   groq: {
@@ -667,6 +677,8 @@ function buildStage1SystemPrompt(schema) {
     'SQL rules:',
     '- Never reference the column named "index" — it is a pandas artifact and a reserved SQLite keyword; always omit it',
     '- Write valid SQLite SELECT statements only',
+    '- The SQLite engine does not support window functions. Never use OVER(), PARTITION BY, ROW_NUMBER(), RANK(), DENSE_RANK(), NTILE(), LAG(), LEAD(), or FILTER(...).',
+    '- To pick the top row(s) within each group, use a correlated subquery instead of a window function: for the single top row per group, keep rows whose value equals (SELECT MAX(value) FROM t2 WHERE t2.group_key = t.group_key); for the top N per group, keep rows whose count of higher-valued peers in the same group is less than N.',
     '- Never use INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, or TRUNCATE',
     '- Use LIMIT 500 for row-level queries; no LIMIT for aggregations by geography',
     '- Column names must exactly match the schema above',
@@ -738,7 +750,7 @@ async function runAnalysis(question) {
 
   // Quote bare `index` keyword (pandas artifact; reserved SQLite word).
   // Matches `index` that is not already inside quotes and not part of a longer word.
-  stage1.sql = stage1.sql.replace(/\b(index)\b(?=(?:[^"]*"[^"]*")*[^"]*$)/gi, '"index"');
+  stage1.sql = normalizeGeneratedSql(stage1.sql);
 
   // SQL safety check
   if (WRITE_BLOCK_RE.test(stage1.sql)) {
@@ -747,16 +759,24 @@ async function runAnalysis(question) {
 
   updateLastStatus('⏳ Executing SQL query…');
 
-  // Execute SQL via worker
+  // Execute SQL via worker, with a guarded auto-repair loop: on a SQLite error
+  // we feed the failing SQL + error back to the model to correct, then re-run,
+  // up to MAX_SQL_RETRIES times. Recovers from errors the engine raises (e.g.
+  // unsupported syntax) without the user having to click "Fix error".
   var sqlResult = await workerExec({ action: 'exec', sql: stage1.sql });
-  if (sqlResult.error) {
-    // Attempt retry with error context
-    stage1 = await retrySQLWithError(question, stage1.sql, sqlResult.error);
+  for (var attempt = 1; sqlResult.error && attempt <= MAX_SQL_RETRIES; attempt++) {
+    stage1 = await retrySQLWithError(question, stage1.sql, sqlResult.error, attempt);
+    if (!stage1.sql) {
+      throw new Error('SQL error and the model did not return a corrected query: ' + sqlResult.error);
+    }
+    stage1.sql = normalizeGeneratedSql(stage1.sql);
     if (WRITE_BLOCK_RE.test(stage1.sql)) {
       throw new Error('Retry produced SQL with disallowed operations.');
     }
     sqlResult = await workerExec({ action: 'exec', sql: stage1.sql });
-    if (sqlResult.error) throw new Error('SQL error after retry: ' + sqlResult.error);
+  }
+  if (sqlResult.error) {
+    throw new Error('SQL error after ' + MAX_SQL_RETRIES + ' repair attempts: ' + sqlResult.error);
   }
 
   var queryResults = sqlResult.results && sqlResult.results[0];
@@ -826,8 +846,9 @@ async function runAnalysis(question) {
   }
 }
 
-async function retrySQLWithError(question, failedSQL, errorMsg) {
-  appendChatMessage('assistant', '⚠️ SQL error, retrying with correction…', 'status');
+async function retrySQLWithError(question, failedSQL, errorMsg, attempt) {
+  var label = attempt ? ' (attempt ' + attempt + '/' + MAX_SQL_RETRIES + ')' : '';
+  appendChatMessage('assistant', '⚠️ SQL error, retrying with correction' + label + '…', 'status');
   var retryMessages = [
     { role: 'system', content: buildStage1SystemPrompt(STATE.schema) },
     { role: 'user', content: question },

--- a/docs/assets/ai_analysis.js
+++ b/docs/assets/ai_analysis.js
@@ -27,6 +27,11 @@ const WRITE_BLOCK_RE = /\b(INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|TRUNCATE)\b/i;
 // error back to the model to correct, up to this many times, before giving up.
 const MAX_SQL_RETRIES = 3;
 
+// Build marker — bump when changing this file so a loaded page can be identified
+// (logged to console and shown next to the DB-status line). Lets you confirm the
+// browser is running the current JS rather than a cached/older build.
+const AI_BUILD = 'sql-compat-retry+diagnostics+models+jsonfix · 2026-07-21';
+
 // Normalize model-generated SQL before execution. Currently quotes the reserved
 // word "index" (a pandas artifact column) when it appears outside string
 // literals. Applied to both first-pass and retried SQL.
@@ -47,7 +52,7 @@ const PROVIDER_CONFIG = {
   },
   gemini: {
     endpoint: 'https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent',
-    defaultModel: 'gemini-2.5-flash',
+    defaultModel: 'gemini-flash-latest',
     format: 'gemini',
   },
 };
@@ -606,7 +611,40 @@ function callGemini(endpointTemplate, apiKey, model, messages) {
 function parseJSON(text) {
   // Strip markdown code fences if present
   var cleaned = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '').trim();
-  return JSON.parse(cleaned);
+  try {
+    return JSON.parse(cleaned);
+  } catch (e) {
+    // Models sometimes wrap the JSON in prose or append commentary after the
+    // closing brace ("Unexpected non-whitespace character after JSON…").
+    // Fall back to extracting the first balanced {...} object and parse that.
+    var obj = extractFirstJSONObject(cleaned);
+    if (obj !== null) return JSON.parse(obj);
+    throw e;
+  }
+}
+
+// Return the first balanced top-level {...} object in a string, ignoring braces
+// inside string literals (escape-aware), or null if none is found.
+function extractFirstJSONObject(s) {
+  var start = s.indexOf('{');
+  if (start < 0) return null;
+  var depth = 0, inStr = false, esc = false;
+  for (var i = start; i < s.length; i++) {
+    var c = s.charAt(i);
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+    } else if (c === '"') {
+      inStr = true;
+    } else if (c === '{') {
+      depth++;
+    } else if (c === '}') {
+      depth--;
+      if (depth === 0) return s.slice(start, i + 1);
+    }
+  }
+  return null;
 }
 
 // ─── System Prompts ──────────────────────────────────────────────────────────
@@ -763,10 +801,17 @@ async function runAnalysis(question) {
   // we feed the failing SQL + error back to the model to correct, then re-run,
   // up to MAX_SQL_RETRIES times. Recovers from errors the engine raises (e.g.
   // unsupported syntax) without the user having to click "Fix error".
+  // Each attempt is recorded; diagnostics are rendered once at the end so a
+  // single-attempt success shows just the SQL that ran (no "initial vs final"),
+  // while a revised query shows the final SQL plus a collapsed list of the
+  // earlier attempts. See renderSqlDiagnostics().
+  var sqlAttempts = [];
   var sqlResult = await workerExec({ action: 'exec', sql: stage1.sql });
+  sqlAttempts.push({ sql: stage1.sql, error: sqlResult.error || null });
   for (var attempt = 1; sqlResult.error && attempt <= MAX_SQL_RETRIES; attempt++) {
     stage1 = await retrySQLWithError(question, stage1.sql, sqlResult.error, attempt);
     if (!stage1.sql) {
+      renderSqlDiagnostics(sqlAttempts, null);
       throw new Error('SQL error and the model did not return a corrected query: ' + sqlResult.error);
     }
     stage1.sql = normalizeGeneratedSql(stage1.sql);
@@ -774,10 +819,13 @@ async function runAnalysis(question) {
       throw new Error('Retry produced SQL with disallowed operations.');
     }
     sqlResult = await workerExec({ action: 'exec', sql: stage1.sql });
+    sqlAttempts.push({ sql: stage1.sql, error: sqlResult.error || null });
   }
   if (sqlResult.error) {
+    renderSqlDiagnostics(sqlAttempts, null);
     throw new Error('SQL error after ' + MAX_SQL_RETRIES + ' repair attempts: ' + sqlResult.error);
   }
+  renderSqlDiagnostics(sqlAttempts, stage1.sql);
 
   var queryResults = sqlResult.results && sqlResult.results[0];
   // sql.js returns [] (empty array) for a SELECT that matched 0 rows — results[0] is undefined
@@ -1401,6 +1449,82 @@ function appendChatMessage(role, text, subtype, artifactId) {
   return div;
 }
 
+// Visual SQL diagnostic: shows an attempt/error/success line plus (optionally)
+// the SQL or error text in a monospace block, so retries and the final query are
+// visible in the chat panel. kind ∈ {'attempt','error','success'}.
+function appendSqlDiagnostic(title, body, kind) {
+  var log = document.getElementById('ai-chat-log');
+  var div = document.createElement('div');
+  div.className = 'ai-chat-msg ai-chat-msg--assistant ai-diagnostic ai-diagnostic--' + (kind || 'attempt');
+  div.setAttribute('data-subtype', 'diagnostic');
+  var html = '<div class="ai-diag-title">' + escapeHTML(title) + '</div>';
+  if (body) html += '<pre class="ai-sql-block">' + escapeHTML(body) + '</pre>';
+  div.innerHTML = html;
+  log.appendChild(div);
+  log.scrollTop = log.scrollHeight;
+  return div;
+}
+
+// Render SQL diagnostics after execution resolves.
+//   attempts : [{sql, error}] in order (error null on the successful run)
+//   finalSql : the SQL that succeeded, or null if every attempt failed
+// If the query was never revised (one attempt), show a single block with the SQL
+// that ran. If it was revised, show the final SQL plus a collapsed <details> of
+// the earlier (failed) attempts, closed by default.
+function renderSqlDiagnostics(attempts, finalSql) {
+  var revised = attempts.length > 1;
+
+  if (finalSql && !revised) {
+    appendSqlDiagnostic('✓ SQL executed successfully', finalSql, 'success');
+    return;
+  }
+
+  var earlier = finalSql ? attempts.slice(0, -1) : attempts;
+
+  if (finalSql) {
+    appendSqlDiagnostic(
+      '✓ SQL executed successfully (after ' + earlier.length +
+        ' revision' + (earlier.length === 1 ? '' : 's') + ')',
+      finalSql, 'success'
+    );
+  } else {
+    appendSqlDiagnostic(
+      'Could not run a valid query after ' + attempts.length + ' attempts',
+      attempts[attempts.length - 1].error, 'error'
+    );
+  }
+
+  if (!earlier.length) return;
+
+  var log = document.getElementById('ai-chat-log');
+  var details = document.createElement('details');
+  details.className = 'ai-chat-msg ai-chat-msg--assistant ai-diagnostic ai-diagnostic--attempt ai-diag-earlier';
+  details.setAttribute('data-subtype', 'diagnostic');
+  var summary = document.createElement('summary');
+  summary.className = 'ai-diag-title';
+  summary.textContent = 'Earlier attempt' + (earlier.length === 1 ? '' : 's') +
+    ' (' + earlier.length + ')';
+  details.appendChild(summary);
+  earlier.forEach(function(a, i) {
+    var t = document.createElement('div');
+    t.className = 'ai-diag-title ai-diag-earlier-label';
+    t.textContent = 'Attempt ' + (i + 1) + ' — failed';
+    details.appendChild(t);
+    var sqlPre = document.createElement('pre');
+    sqlPre.className = 'ai-sql-block';
+    sqlPre.textContent = a.sql;
+    details.appendChild(sqlPre);
+    if (a.error) {
+      var errPre = document.createElement('pre');
+      errPre.className = 'ai-sql-block';
+      errPre.textContent = 'Error: ' + a.error;
+      details.appendChild(errPre);
+    }
+  });
+  log.appendChild(details);
+  log.scrollTop = log.scrollHeight;
+}
+
 function updateLastStatus(text) {
   var log = document.getElementById('ai-chat-log');
   var statusMsgs = log.querySelectorAll('[data-subtype="status"]');
@@ -1516,7 +1640,8 @@ async function handleSubmit() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', function() {
+if (typeof document !== 'undefined') document.addEventListener('DOMContentLoaded', function() {
+  console.log('[AMEND AI] build: ' + AI_BUILD);
   initWorker();
   populateSettingsUI();
   fetchSemanticContext();
@@ -1556,3 +1681,14 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   });
 });
+
+// CommonJS export of the pure, DOM-free helpers so they can be unit-tested with
+// `node --test`. No effect in the browser (module is undefined there).
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    parseJSON: parseJSON,
+    extractFirstJSONObject: extractFirstJSONObject,
+    normalizeGeneratedSql: normalizeGeneratedSql,
+    buildStage1SystemPrompt: buildStage1SystemPrompt,
+  };
+}

--- a/docs/assets/ai_analysis.test.js
+++ b/docs/assets/ai_analysis.test.js
@@ -1,0 +1,69 @@
+// Unit tests for the pure, DOM-free helpers in ai_analysis.js.
+// Run with: node --test docs/assets/   (Node >= 18, no dependencies)
+//
+// These lock in the fixes for:
+//   - LLM SQL that used unsupported window functions (prompt rule)
+//   - JSON responses with prose/commentary after the object (parseJSON)
+//   - the reserved-word `index` quoting (normalizeGeneratedSql)
+
+const test = require('node:test');
+const assert = require('node:assert');
+const ai = require('./ai_analysis.js');
+
+test('parseJSON: plain object', () => {
+  assert.deepStrictEqual(ai.parseJSON('{"sql": null, "reasoning": "ok"}'),
+    { sql: null, reasoning: 'ok' });
+});
+
+test('parseJSON: strips ```json code fences', () => {
+  assert.deepStrictEqual(ai.parseJSON('```json\n{"sql":"SELECT 1"}\n```'),
+    { sql: 'SELECT 1' });
+});
+
+test('parseJSON: tolerates trailing prose after the JSON object', () => {
+  // The exact failure the user hit: "Unexpected non-whitespace character
+  // after JSON at position 563".
+  const r = ai.parseJSON('{"sql":"SELECT 1","reasoning":"x"}\n\nHere is why: trailing prose.');
+  assert.strictEqual(r.sql, 'SELECT 1');
+});
+
+test('parseJSON: leading prose + braces inside string literals', () => {
+  const r = ai.parseJSON('Sure!\n{"sql":null,"answer":"because {nested} braces"}\n\nHope that helps.');
+  assert.strictEqual(r.answer, 'because {nested} braces');
+});
+
+test('parseJSON: still throws when there is no JSON at all', () => {
+  assert.throws(() => ai.parseJSON('not json, no braces here'));
+});
+
+test('extractFirstJSONObject: returns null when no object present', () => {
+  assert.strictEqual(ai.extractFirstJSONObject('nothing to see'), null);
+});
+
+test('extractFirstJSONObject: ignores braces inside strings', () => {
+  assert.strictEqual(
+    ai.extractFirstJSONObject('{"a":"}{"}trailing'),
+    '{"a":"}{"}'
+  );
+});
+
+test('normalizeGeneratedSql: quotes a bare `index` keyword', () => {
+  assert.match(ai.normalizeGeneratedSql('SELECT index FROM t'), /"index"/);
+});
+
+test('normalizeGeneratedSql: leaves an already-quoted string literal alone', () => {
+  const out = ai.normalizeGeneratedSql('SELECT a FROM t WHERE b = "index"');
+  assert.strictEqual((out.match(/"index"/g) || []).length, 1);
+});
+
+test('buildStage1SystemPrompt: forbids window functions', () => {
+  const p = ai.buildStage1SystemPrompt('CREATE TABLE t (a INTEGER);');
+  assert.match(p, /window functions/i);
+  assert.match(p, /ROW_NUMBER/);
+  assert.match(p, /PARTITION BY/);
+});
+
+test('buildStage1SystemPrompt: recommends the correlated-subquery pattern', () => {
+  const p = ai.buildStage1SystemPrompt('CREATE TABLE t (a INTEGER);');
+  assert.match(p, /correlated subquery/i);
+});


### PR DESCRIPTION
## Problem

On the Ask AMEND AI page, questions like *"highest paid DEP employees in each of the past 5 years"* fail with:

```
Error: Uncaught Error: near "(": syntax error
```

The client-side SQLite engine (`sql.js`) has no window functions, but the model emits `ROW_NUMBER() OVER (PARTITION BY CalendarYear ...)`; `OVER (` is where the parser throws.

## Fix (stage 1 of 2)

- **Prompt rule** — the Stage-1 system prompt now forbids window functions (`OVER`, `PARTITION BY`, `ROW_NUMBER`, `RANK`, `DENSE_RANK`, `NTILE`, `LAG`, `LEAD`, `FILTER`) and steers top-per-group questions to the correlated-subquery pattern the engine supports.
- **Guarded auto-repair loop** — the previous single SQL retry is generalized into a loop that feeds the failing SQL + error back to the model and re-runs, up to `MAX_SQL_RETRIES` (**3**) attempts, before surfacing the error. This recovers from engine errors automatically instead of requiring the user to click "Fix error".
- **`normalizeGeneratedSql()`** — extracted the reserved-word `index` quoting into a helper and now apply it to retried SQL too (the old single-retry path skipped it).

Deferred to a follow-up branch: **upgrading `sql.js` to a modern WASM build** so window functions actually work (larger change — new `.wasm` asset + worker-protocol/IndexedDB rework + browser testing).

## Verification

- `node --check` passes on `ai_analysis.js`.
- Confirmed the correlated-subquery pattern the prompt now recommends runs on the real DB and returns one top earner per year.

🤖 Generated with [Claude Code](https://claude.com/claude-code)